### PR TITLE
Updated CoMW.yml

### DIFF
--- a/CoMW.yml
+++ b/CoMW.yml
@@ -18,7 +18,7 @@ dependencies:
   - infernal=1.1.1
   - emboss=6.6.0
   - bwa=0.7.17
-  - sword=1.0.3
+  - sword=1.0.4
   - asn1crypto=0.24.0
   - chardet=3.0.4
   - cryptography=2.8


### PR DESCRIPTION
Updated `sword` package in `CoMW.yml`

`Sword=1.0.03` was not compatible with few servers due to `AVX2` command passed by the flag `-mno-avx2`. `sword` was updated by the author. (Thank you Robert). 